### PR TITLE
feat: sequential-pool active learning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,31 @@ pytest tests/test_learning.py
 2. Main loop: select samples → forget samples → evaluate (periodic) → save checkpoints
 3. Output: `al_traj.csv` (metrics trajectory), final train/pool datasets
 
+### Sequential-Pool Active Learning (`dev/sp` branch)
+
+Splits the pool into equal-sized subsets and runs AL on each subset sequentially. Early stopping per subset prevents selecting redundant data: when the uncertainty of the selected sample drops below a threshold, AL moves to the next subset.
+
+**CLI arguments:**
+- `--n_pool_subsets N` — Number of equal-sized subsets to split the pool into (requires explorative selection)
+- `--sp_uncertainty_cutoff FLOAT` — Uncertainty threshold; when the selected sample's uncertainty falls below this, stop on current subset
+- `--max_iter N` — In sequential-pool mode, this is the max iterations *per subset*
+
+**Implementation files:**
+- `molalkit/exe/run.py` — `_split_pool_uidx()`, `_build_pool_datasets()`, `_should_stop_early()`, `_run_al_loop()` helper functions; main loop iterates over subsets
+- `molalkit/active_learning/learner.py` — `ActiveLearner.set_pool()` method for swapping pool at runtime
+
+**Example:**
+```bash
+molalkit_run --data_public bace --metrics roc_auc \
+  --model_configs RandomForest_Morgan_Config \
+  --split_type random --split_sizes 0.5 0.5 \
+  --select_method explorative --s_batch_size 1 \
+  --n_pool_subsets 4 --sp_uncertainty_cutoff 0.35 \
+  --max_iter 500 --evaluate_stride 10 --seed 0 --save_dir ./results
+```
+
+Works with yoked learning (multiple `--model_configs`), `--full_val`, and precomputed graph kernels.
+
 ### Key Patterns
 
 - Factory functions: `get_model()`, `get_kernel()` for model instantiation

--- a/molalkit/__init__.py
+++ b/molalkit/__init__.py
@@ -2,4 +2,4 @@
 # -*- coding: utf-8 -*-
 
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"

--- a/molalkit/active_learning/learner.py
+++ b/molalkit/active_learning/learner.py
@@ -184,6 +184,10 @@ class ActiveLearner:
         self.current_iter += 1
         self.active_learning_traj.results.append(alr)
 
+    def set_pool(self, datasets_pool):
+        """Replace the current pool datasets with new ones (for sequential-pool AL)."""
+        self.datasets_pool = datasets_pool
+
     def evaluate(self):
         if len(self.active_learning_traj.results) == 0:
             alr = ActiveLearningResult(self.current_iter - 1)

--- a/molalkit/exe/args.py
+++ b/molalkit/exe/args.py
@@ -562,6 +562,13 @@ class LearningArgs(DatasetModelArgs, SelectorArgs, ForgetterArgs, EvaluationArgs
     """write trajectory file every no. steps of select-forget loops."""
     load_checkpoint: bool = False
     """load checkpoint file and continue the active learning."""
+    n_pool_subsets: int = None
+    """number of equal-sized subsets to split the pool into for sequential-pool active learning.
+    If None, standard (static-pool) active learning is used."""
+    sp_uncertainty_cutoff: float = None
+    """uncertainty threshold for early stopping in sequential-pool active learning.
+    When the uncertainty of the latest selected sample falls below this threshold,
+    AL stops on the current pool subset and moves to the next."""
 
     @property
     def top_uidx(self) -> Optional[List[int]]:
@@ -599,7 +606,16 @@ class LearningArgs(DatasetModelArgs, SelectorArgs, ForgetterArgs, EvaluationArgs
         if self.forget_method is not None:
             assert self.n_forget > 0, "n_forget must be greater than 0."
 
-        if self.max_iter is None:
+        # Validate sequential-pool arguments
+        if self.n_pool_subsets is not None:
+            assert self.n_pool_subsets >= 2, "n_pool_subsets must be >= 2."
+            assert self.select_method == "explorative", \
+                "sequential-pool active learning currently only supports explorative selection."
+            assert self.sp_uncertainty_cutoff is not None, \
+                "sp_uncertainty_cutoff must be set for sequential-pool active learning."
+            assert self.sp_uncertainty_cutoff > 0, "sp_uncertainty_cutoff must be positive."
+
+        if self.max_iter is None and self.n_pool_subsets is None:
             dn = self.n_select - self.n_forget
             if dn > 0:
                 self.max_iter = len(self.datasets_pool[0]) // dn

--- a/molalkit/exe/run.py
+++ b/molalkit/exe/run.py
@@ -5,8 +5,10 @@ import torch
 torch.cuda.is_available()
 import os
 import shutil
+import numpy as np
 import pandas as pd
 from molalkit.active_learning.learner import ActiveLearner
+from molalkit.data.utils import get_subset_from_uidx
 from molalkit.exe.args import LearningArgs
 
 
@@ -26,6 +28,82 @@ def _free_init_memory(args):
         if hasattr(args, attr):
             delattr(args, attr)
     gc.collect()
+
+
+def _split_pool_uidx(datasets_pool, n_subsets, seed=0):
+    """Split pool dataset uidx list into n equal-sized subsets.
+
+    Returns a list of n lists of uidx values.
+    """
+    all_uidx = [data.uidx for data in datasets_pool[0]]
+    rng = np.random.RandomState(seed)
+    rng.shuffle(all_uidx)
+    return [arr.tolist() for arr in np.array_split(all_uidx, n_subsets)]
+
+
+def _build_pool_datasets(uidx_list, id2datapoints, datasets_pool):
+    """Build pool datasets from a list of uidx values.
+
+    Uses the first element of datasets_pool as a template (for copy structure).
+    """
+    return [get_subset_from_uidx(ds, id2dp, uidx_list)
+            for ds, id2dp in zip(datasets_pool, id2datapoints)]
+
+
+def _should_stop_early(active_learner, uncertainty_cutoff):
+    """Check if the latest selected sample's uncertainty is below the threshold.
+
+    Returns True if AL should stop on the current pool subset.
+    """
+    if uncertainty_cutoff is None:
+        return False
+    results = active_learner.active_learning_traj.results
+    if not results:
+        return False
+    latest = results[-1]
+    if not latest.acquisition_select:
+        return False
+    # acquisition_select contains uncertainties of selected samples;
+    # check the minimum (the least uncertain selected sample)
+    min_acquisition = min(latest.acquisition_select)
+    return min_acquisition < uncertainty_cutoff
+
+
+def _run_al_loop(active_learner, args, start_iter, max_iter):
+    """Run the standard AL loop. Returns the iteration count reached and whether early-stopped."""
+    logger = args.logger
+    for i in range(start_iter, max_iter):
+        logger.info("Active learning loop %d" % i)
+        for _ in range(args.n_select):
+            active_learner.step_select()
+            logger.debug("Select step %d" % _)
+        # Check early stopping for sequential-pool
+        if args.n_pool_subsets is not None and _should_stop_early(active_learner, args.sp_uncertainty_cutoff):
+            logger.info("Early stopping: uncertainty below threshold %.4f at iteration %d"
+                        % (args.sp_uncertainty_cutoff, i))
+            if args.evaluate_stride is not None:
+                active_learner.evaluate()
+            active_learner.write_traj()
+            return i + 1, True
+        if args.f_min_train_size is None or len(active_learner.datasets_train[0]) >= args.f_min_train_size:
+            for _ in range(args.n_forget):
+                active_learner.step_forget()
+                logger.debug("Forget step %d" % _)
+        if args.evaluate_stride is not None and i % args.evaluate_stride == 0:
+            active_learner.evaluate()
+            logger.debug("Evaluate step")
+        if i % args.write_traj_stride == 0:
+            active_learner.write_traj()
+        if args.save_cpt_stride is not None and i % args.save_cpt_stride == 0:
+            active_learner.current_iter = i + 1
+            active_learner.save(path=args.save_dir, filename="al_temp.pkl", overwrite=True)
+            shutil.move(os.path.join(args.save_dir, "al_temp.pkl"), os.path.join(args.save_dir, "al.pkl"))
+            logger.info("Save checkpoint file %s/al.pkl" % args.save_dir)
+        # Stop if pool is exhausted
+        if len(active_learner.datasets_pool[0]) == 0:
+            logger.info("Pool exhausted at iteration %d" % i)
+            return i + 1, True
+    return max_iter, False
 
 
 def molalkit_run(arguments=None):
@@ -54,25 +132,35 @@ def molalkit_run(arguments=None):
         current_iter = 0
         active_learner.evaluate()
     _free_init_memory(args)
-    for i in range(current_iter, args.max_iter or 100):
-        logger.info("Active learning loop %d" % i)
-        for _ in range(args.n_select):
-            active_learner.step_select()
-            logger.debug("Select step %d" % _)
-        if args.f_min_train_size is None or len(active_learner.datasets_train[0]) >= args.f_min_train_size:
-            for _ in range(args.n_forget):
-                active_learner.step_forget()
-                logger.debug("Forget step %d" % _)
-        if args.evaluate_stride is not None and i % args.evaluate_stride == 0:
-            active_learner.evaluate()
-            logger.debug("Evaluate step")
-        if i % args.write_traj_stride == 0:
-            active_learner.write_traj()
-        if args.save_cpt_stride is not None and i % args.save_cpt_stride == 0:
-            active_learner.current_iter = i + 1
-            active_learner.save(path=args.save_dir, filename="al_temp.pkl", overwrite=True)
-            shutil.move(os.path.join(args.save_dir, "al_temp.pkl"), os.path.join(args.save_dir, "al.pkl"))
-            logger.info("Save checkpoint file %s/al.pkl" % args.save_dir)
+
+    if args.n_pool_subsets is not None:
+        # Sequential-pool active learning
+        pool_uidx_subsets = _split_pool_uidx(active_learner.datasets_pool, args.n_pool_subsets, seed=args.seed)
+        # Store reference datasets_pool templates for building subsets
+        template_pools = active_learner.datasets_pool
+        max_iter_per_pool = args.max_iter or 100
+        # Collect remaining (unselected) uidx across all subsets
+        all_remaining_uidx = []
+
+        for pool_idx, uidx_subset in enumerate(pool_uidx_subsets):
+            logger.info("Sequential-pool: starting pool subset %d/%d (size=%d)"
+                        % (pool_idx + 1, args.n_pool_subsets, len(uidx_subset)))
+            subset_pools = _build_pool_datasets(uidx_subset, args.id2datapoints, template_pools)
+            active_learner.set_pool(subset_pools)
+            active_learner.model_fitted = False
+            current_iter, _ = _run_al_loop(active_learner, args, current_iter, current_iter + max_iter_per_pool)
+            # Collect remaining pool uidx from this subset
+            all_remaining_uidx.extend([data.uidx for data in active_learner.datasets_pool[0]])
+        # Add uidx from unprocessed subsets (subsets never reached due to iteration limits are
+        # already handled since we always iterate all subsets above)
+        # Set final pool to all remaining data for correct pool_end.csv output
+        final_pools = _build_pool_datasets(all_remaining_uidx, args.id2datapoints, template_pools)
+        active_learner.set_pool(final_pools)
+        active_learner.write_traj()
+    else:
+        # Standard (static-pool) active learning
+        _run_al_loop(active_learner, args, current_iter, args.max_iter or 100)
+
     df = pd.read_csv(f"{args.save_dir}/full.csv")
     df[df["uidx"].isin([data.uidx for data in active_learner.datasets_train[0]])].to_csv(f"{args.save_dir}/train_end.csv", index=False)
     df[df["uidx"].isin([data.uidx for data in active_learner.datasets_pool[0]])].to_csv(f"{args.save_dir}/pool_end.csv", index=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "molalkit"
 description = "MolALKit: A Toolkit for Active Learning in Molecular Data."
-version = "1.0.1"
+version = "1.1.0"
 authors = [
     {name = "Yan Xiang", email="yan.xiang@duke.edu"}
 ]


### PR DESCRIPTION
## Summary
- Add sequential-pool (SP) active learning mode that splits the pool into equal-sized subsets and runs explorative AL on each sequentially
- Early stopping per subset: when the selected sample's uncertainty drops below `--sp_uncertainty_cutoff`, AL moves to the next subset, avoiding redundant selections
- New CLI args: `--n_pool_subsets`, `--sp_uncertainty_cutoff`
- Bump version to 1.1.0

## Changed files
- `molalkit/exe/run.py` — Refactored AL loop into helpers; added SP orchestration with `_split_pool_uidx()`, `_build_pool_datasets()`, `_should_stop_early()`, `_run_al_loop()`
- `molalkit/exe/args.py` — New `n_pool_subsets` and `sp_uncertainty_cutoff` arguments with validation
- `molalkit/active_learning/learner.py` — Added `ActiveLearner.set_pool()` for swapping pool at runtime
- `CLAUDE.md` — Documented SP feature
- `pyproject.toml`, `molalkit/__init__.py` — Version bump

## Test plan
- [x] Static-pool AL still works (no SP args)
- [x] SP with RandomForest classification (dili dataset, 3 subsets)
- [x] Early stopping triggers correctly (high cutoff → immediate stop)
- [x] Yoked learning with SP (2 models: RandomForest + LogisticRegression)
- [x] Full-data mode (`--full_val`, no split) with GP regression + graph kernel (1728 samples, 4 subsets, cutoff=0.35)
- [x] Verified per-subset early stopping behavior: later subsets need fewer iterations as model improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)